### PR TITLE
Change target repo for positions drafts

### DIFF
--- a/de/positions.md
+++ b/de/positions.md
@@ -33,12 +33,12 @@ Der Entwicklungsprozess für die Positionen der Gesellschaft wurde durch die Mit
 ### 1. Aufruf- und Arbeitsphase
 
 1. **Call for Collaboration:** Initiatorinnen und Initiatoren einer Position kündigen das Thema auf der Mailingliste der Gesellschaft (liste@de-rse.org, mit Thema `[Call for Contribution]`) an und rufen die Mitglieder zur Mitarbeit auf. Dabei werden Hauptautorinnen und -autoren des Positionstextes benannt und die Bedingungen für Mitautorschaft erläutert.
-2. **Zusammenarbeit:** Zusammenarbeit beginnt auf einer bevorzugt öffentlichen Plattform nach Wahl der Initiatorinnen und Initiatoren (\*Pad, Repository, hackmd.io, Overleaf, o.ä.). Das Projekt wird gleichzeitig vorgestellt und verlinkt auf der de-rse.org Website unter ["Positionen" > "Work in progress"](https://www.de-rse.org/de/positions.html#work-in-progress).
+2. **Zusammenarbeit:** Zusammenarbeit beginnt auf einer bevorzugt öffentlichen Plattform nach Wahl der Initiatorinnen und Initiatoren (\*Pad, Repository, hackmd.io, Overleaf, o.ä.). Das Projekt wird gleichzeitig vorgestellt und verlinkt auf der de-rse.org Website unter ["Positionen" > "Work in progress"](https://www.de-rse.org/de/positions.html#work-in-progress) (per Pull Request gegen die Positionen-Seiten (de/en) auf <https://github.com/DE-RSE/de-rse.github.io>).
 
 ### 2. Begutachtungsphase
 
 1. **Veröffentlichung:** Nach Fertigstellung eines zur Veröffentlichung vorgeschlagenen Entwurfs wird dieser zur Begutachtung freigegeben:
-    - Soll die Position auf der de-RSE-Website unter "Positionen" veröffentlicht werden, wird ein entsprechender Pull Request (PR) gegen <https://github.com/DE-RSE/www> gestellt.
+    - Soll die Position auf der de-RSE-Website unter "Positionen" veröffentlicht werden, wird ein entsprechender Pull Request (PR) gegen <https://github.com/DE-RSE/positions/> gestellt (Entwurfsdateien in einem dedizierten Unterordner).
     - Ist eine andere Veröffentlichungsform vorgesehen, wird ein entsprechendes Issue auf <https://github.com/DE-RSE/projekte> eröffnet, das einen Link zum Entwurf enthält.
 2. **Call for Reviews:** Die Entwurfsveröffentlichung wird wiederum über die Mailingliste (liste@de-rse.org, mit Thema `[Call for Reviews]`) bekanntgegeben, mit Link zum Pull Request/Issue. Die Mitgliedschaft wird zur Begutachtung bis zu einem geeigneten Termin aufgerufen.
 3. **Begutachtung:** Die Mitgliedschaft begutachtet öffentlich den Entwurf im PR/Issue. Sollte der Entwurf eine kontroverse Diskussion initiieren, ist der PR/Issue mit einem Label `[Kontroverse]` zu markieren. Kontroverse Diskussionen/Gutachten sind solche, die in einem Peer-Review-Verfahren zu einer ablehnenden Entscheidung oder eine "Major revision" führen würden.

--- a/en/positions.md
+++ b/en/positions.md
@@ -33,12 +33,12 @@ The development process for positions of the Society has been developed by its m
 ### 1. Call and work phase
 
 1. **Call for Collaboration:** Initiators of a position announce the topic on the Society's mailing list (list@de-rse.org, with subject `[Call for contributions]`), and invite all members to collaborate. The call names main authors of the position text, and explains the prerequisites for authorship.
-2. **Collaboration:** Collaboration starts on a - preferably public - platform of the initiators' choice (\*Pad, repository, hackmd.io, Overleaf, etc.). At the same time, the project is presented and linked to on the de-rse.org website under ["Positions" > "Work in progress"](https://www.de-rse.org/en/positions.html#work-in-progress).
+2. **Collaboration:** Collaboration starts on a - preferably public - platform of the initiators' choice (\*Pad, repository, hackmd.io, Overleaf, etc.). At the same time, the project is presented and linked to on the de-rse.org website under ["Positions" > "Work in progress"](https://www.de-rse.org/en/positions.html#work-in-progress) (per Pull Request against the Positions pages (en/de) on <https://github.com/DE-RSE/de-rse.github.io>).
 
 ### 2. Review phase
 
 1. **Publication:** Once a draft is deemed ready for publication, it is published for review:
-    - If the position is to be published on the de-RSE website under "Positions", a respective pull request (PR) is created against <https://github.com/DE-RSE/www>.
+    - If the position is to be published on the de-RSE website under "Positions", a respective pull request (PR) is created against <https://github.com/DE-RSE/positions/>  (Draft files in a dedicated subfolder).
     - If the position is to be published in another format, a respective issue is created on <https://github.com/DE-RSE/projekte>, which contains a link to the draft.
 2. **Call for reviews:** The draft publication is announced on the mailing list (liste@de-rse.org, with subject `[Call for Reviews]`), and the link to the respective issue/PR is provided. All members are invited to review the draft until a suitable date.
 3. **Reviews:** Members review the draft publicly in the PR/issue. Should the draft initiate a controversial discussion, the PR/issue is marked with the label `[Kontroverse]`. Controversial discussions/reviews are those which, in a peer review process, would lead to a rejection or "major revision" decision.


### PR DESCRIPTION
Some minor changes on the positions pages:

- Update URL for this repo
- Change the target repository for positions drafts to https://github.com/de-rse/positions/. This because:
  - It makes it easier to track positions drafts outside of this repo (SoC)
  - Final publication-ready positions can be moved to de-rse/positions/' `gh-pages` branch an can be rendered from there directly.