### PR TITLE
Add a docker based local dev setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM jekyll/builder:stable
+
+# one time install/init of dependencies
+COPY Rakefile Gemfile* /srv/jekyll/
+RUN cd /srv/jekyll && \
+  jekyll build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '2'
+
+# install required jekyll dependencies in image
+# serve at http://localhost:4000/ with `docker-compose up`
+# jekyll will watch for file changes and incrementally rebuild the site
+# you can run one-off rake tasks with `docker-compose run site rake SOME_TASK`
+
+services:
+  site:
+    image: derse/jekyll
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+    ports:
+      - 4000:4000
+    volumes:
+      - ./:/srv/jekyll
+    restart: "no"
+    command: >
+      jekyll serve --watch --incremental


### PR DESCRIPTION
Since I never seem to manage to get the right ruby stuff installed on my machine I've added a docker based setup so I do not have to. 

This installs required jekyll dependencies in image
and serves at http://localhost:4000/ with `docker-compose up`
Jekyll will watch for file changes and incrementally rebuild the site

You can run one-off rake tasks with `docker-compose run site rake
SOME_TASK`