### PR TITLE
Fix un-deRSE23 date

### DIFF
--- a/_includes/events/2023.md
+++ b/_includes/events/2023.md
@@ -1,2 +1,2 @@
 | deRSE 2023 | 2023-02-20 - 2023-02-21 | Heinz Nixdof Forum Paderborn | tba | Co-located with SE23 |
-| deRSE Unconference 2023 | Sept. 2023 | Jena | tba | |
+| deRSE Unconference 2023 | 2023-09-12 - 2023-09-14 | Jena | [un-deRSE23](/unconf2023/) | |

--- a/en/events.md
+++ b/en/events.md
@@ -14,6 +14,13 @@ If you think, we are missing an event, please [contact](join.html) us.
 
 We organize the international **deRSE** conferences, by and for Research Software Engineers.
 
+## 2023
+
+| Event | Date | Place | URL | Remarks |
+| --- | --- | --- | --- | --- |
+{% include events/2022.md %}
+{: .table .table-hover}
+
 ## 2022
 
 | Event | Date | Place | URL | Remarks |


### PR DESCRIPTION
The date for the de-RSE Unconference 2023 is fixed and I added it to the event list.

The event homepage is already linked but not much content yet... will be filled this week.
I also added the 2023 events to the englisch event list - I forgot about this in the last PR.