### PR TITLE
Fix english event list include for 2023

### DIFF
--- a/en/events.md
+++ b/en/events.md
@@ -18,7 +18,7 @@ We organize the international **deRSE** conferences, by and for Research Softwar
 
 | Event | Date | Place | URL | Remarks |
 | --- | --- | --- | --- | --- |
-{% include events/2022.md %}
+{% include events/2023.md %}
 {: .table .table-hover}
 
 ## 2022


### PR DESCRIPTION
English version of the event list included `events/2022.md` twice instead of using the correct `events/2023.md` for next year's events.