### PR TITLE
Ask people to use a subject tag when posting jobs to the mailing list

### DIFF
--- a/de/join.md
+++ b/de/join.md
@@ -42,8 +42,10 @@ Für Diskussionen bitte nicht die Mailing Liste nutzen, sondern den GWDG RocketC
 
 ## Stellenangebote
 
-Für Stellenangebote können derzeit neben der Mailing Liste auch der GWDG RocketChat Channel
-<https://chat.gwdg.de/channel/derse_jobs> genutzt werden.
+Stellenangebote können über folgende Kanäle beworben werden:
+- GWDG RocketChat Channel
+<https://chat.gwdg.de/channel/derse_jobs>
+- Mailing Liste (bitte den Betreff mit "[JOBS]" beginnen, z.B. "[JOBS] unbefristete Stelle als RSE Gruppenleitung")
 
 ## Monatlicher Call
 

--- a/en/join.md
+++ b/en/join.md
@@ -43,8 +43,11 @@ Please don't use the mailing list for long discussions, use the GWDG RocketChat 
 
 ## Job offers
 
-Job offers can be announced on the mailing list, but also on the GWDG RocketChat channel
-<https://chat.gwdg.de/channel/derse_jobs>.
+
+Job offers can be announced through the followin channels:
+- GWDG RocketChat Channel
+<https://chat.gwdg.de/channel/derse_jobs>
+- Mailing list (please start you subject line with "[JOBS]", for example "[JOBS] permanent position as RSE group leader")
 
 ## Monthly Community Call
 


### PR DESCRIPTION
There was a discussion on the de-RSE mailing list and I think this is a good compromise between people who are annoyed by the job postings and people who want to receive them through the list. What do you think?