### PR TITLE
Footer: Add link to GitHub

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,6 @@
 <div class="footer">
 	<a href="{{ "./imprint.html" }}">Impressum (legal notice)</a> | 
+	<a href="https://github.com/DE-RSE/de-rse.github.io">Edit on GitHub</a> | 
 	<a href='{{ "/feed.xml" | prepend: site.baseurl }}'><img src='{{ "/assets/img/site/feed-icon.png" | prepend: site.baseurl }}' alt='Atom 1.0 Feed' style="height: 20px;"></a> | 
 	<span style="position: relative; top: 6px;"><a href="https://twitter.com/RSE_de?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="false" data-dnt="true" alt="Twitter account">Follow @RSE_de</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></span>
 </div>


### PR DESCRIPTION
The fact that this website is on GitHub and that anyone can contribute is really great. However, one can only guess so, as there seems to be no link to this repository anywhere.

Ideally, I would expect this in the footer, which already serves a similar purpose for the Impressum, RSS, and Twitter.

This PR adds just a tiny "Edit on GitHub" link (with the same separator and space). This could be improved in different ways, but better in separate PRs, e.g., by:

- replacing the text with a GitHub logo (would need to add the logo as an image, or fetch it from somewhere, or use font-awesome to type it).
- pointing directly to the exact file to edit, depending on the page you are looking at. We do this at [precice.org](https://precice.org/docs.html) ([repo](https://github.com/precice/precice.github.io)), but it is more complicated: we define the path to edit in every content file.

I have some trouble building the website on my system, so I have not checked the result.