### PR TITLE
Add chapters link under Join

### DIFF
--- a/de/join.md
+++ b/de/join.md
@@ -68,6 +68,12 @@ Der Blog auf der Webseite wird von der Community gemeinschaftlich gestaltet.
 Deine Ideen, Themen und Beiträge auf Deutsch, English, oder beidem sind sehr willkommen!
 In der `README` findest du eine Anleitung wie Du eine Vorschau der Seite auf deinem eigenen Rechner bekommen kannst.
 
+## Lokale RSE Gruppen
+
+"Chapters" sind lokale, regionale, oder institutionspezifische Gruppen von RSEs unter dem Dach von de-RSE e.V..
+
+[Lokale Chapters](https://de-rse.org/chapter/)
+
 # Kontakt
 
 Wer mehr über Hintergründe, Ziele und Aktivitäten wissen möchte oder Fragen zu 

--- a/en/join.md
+++ b/en/join.md
@@ -68,6 +68,12 @@ The website hosts a blog with contributions from the community members.
 Your ideas, topics and posts in German, English, or both are very welcome!
 The `README` includes instructions for getting a local preview of the site.
 
+## Local RSE groups
+
+"Chapters" are local, regional, or institution-specific RSE groups, under the umbrella of the de-RSE.e.V..
+
+[Local chapters](https://de-rse.org/chapter/)
+
 # Contact
 
 Of course please do not hesitate to use the mailing list liste@de-RSE.org if


### PR DESCRIPTION
Closes https://github.com/DE-RSE/de-rse.github.io/issues/254 and https://github.com/DE-RSE/chapter/issues/4.

Note that I have some trouble building this website locally, so I have not tested the changes.
I am not sure if a relative link to just `/chapter/` would work, I guess there is no harm in specifying the full path to https://de-rse.org/chapter/.