### PR TITLE
No menu entry if weight <= 0

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -31,7 +31,7 @@
                 {% assign pg = site.pages | sort: "weight" %}
                 {% for node in pg %}
                     <!-- Neglect imprint.html and index.html in either language -->
-                    {% unless node.path contains "imprint" or node.path contains "index" %}
+                    {% unless node.path contains "imprint" or node.path contains "index" or node.weight <= 0 %}
                         <!-- Set variable "node_conf2019" if node links to a conference page -->
                         {% assign node_conf2019 = false %}
                         {% if node.url contains "/conf2019/" %}

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -31,7 +31,7 @@
                 {% assign pg = site.pages | sort: "weight" %}
                 {% for node in pg %}
                     <!-- Neglect imprint.html and index.html in either language -->
-                    {% unless node.path contains "imprint" or node.path contains "index" or node.weight <= 0 %}
+                    {% unless node.weight == nul or node.weight <= 0 %}
                         <!-- Set variable "node_conf2019" if node links to a conference page -->
                         {% assign node_conf2019 = false %}
                         {% if node.url contains "/conf2019/" %}


### PR DESCRIPTION
This patch allows hosting of pages without a menu entry. At the moment, all pages would create a menu entry, even those without a weight set.