### PR TITLE
Survey of RSE conferences

### DIFF
--- a/_includes/events/2019.md
+++ b/_includes/events/2019.md
@@ -7,3 +7,4 @@
 | deRSE19 | 4.-6.6.2019 | Potsdam | [www.de-rse.org/de/conf2019/](https://www.de-rse.org/de/conf2019/) |
 | FrOSCon | 10.-11.8.2019 | Sankt Augustin | [froscon.de](https://www.froscon.de/) |
 | Fourth RSE conference| 17-19 September 2019 | University of Birmingham | [rse.ac.uk/conf2019/](https://web.archive.org/web/20211009200055/https://rse.ac.uk/conf2019/) |
+| NL-RSE19 | 2019-11-20 | Amsterdam | [nl-rse.org/events/nl-rse19](https://nl-rse.org/events/nl-rse19) | |

--- a/_includes/events/2020.md
+++ b/_includes/events/2020.md
@@ -1,2 +1,5 @@
 | SORSE | 09/2020-12/2020 | online | [https://sorse.github.io/](https://sorse.github.io/) | A Series of Online Research Software Events |
 | deRSE20 - _cancelled_ | ~~25.-27.8.2020~~ | ~~Jena~~ | [www.de-rse.org/deRSE20/](https://www.de-rse.org/deRSE20/) | |
+| FOSDEM'20 | 2020-02-01 - 2020-02-02 | Brussels | [FOSDEM'20](https://archive.fosdem.org/2020/) | |
+| RSDD20 | 2020-12-03 | online | [www.be-rse.org/rsdd2020](https://web.archive.org/web/20200922063305/https://www.be-rse.org/rsdd2020) | Research Software Developers Day |
+| NZRSE 2020 | 2020-09-08 - 2020-09-10 | online | [NZRSE 2020](https://www.rseconference.nz/2020-nzrse-conference/) | RSE Conference New Zealand |

--- a/_includes/events/2021.md
+++ b/_includes/events/2021.md
@@ -1,1 +1,6 @@
 | SeptembRSE | 2021-09-06 - 2021-09-30 | online | [https://septembrse.society-rse.org/](https://septembrse.society-rse.org/) | Funding available from de-RSE |
+| WoSSS21 | 2021-10-06 - 2021-10-08 | online | [WoSSS21](https://wosss.org/wosss21/home) | Workshop on Sustainable Software Sustainability |
+| Nordic-RSE Unconference 2021 | 2021-06-29 - 2021-06-30 | online | [CRSC21](https://nordic-rse.org/events/2021-online-unconference/) | |
+| FOSDEM'21 | 2021-02-06 - 2021-02-07 | online | [FOSDEM'21](https://archive.fosdem.org/2021/) | |
+| CRSC21 | 2021-07-06 - 2021-07-08 | online | [CRSC21](https://www.canarie.ca/event/crsc-2021/) | Canadian Research Software Conference |
+| NZRSE 2021 | 2021-09-15 - 2021-09-17 | online | [NZRSE 2021](https://www.rseconference.nz/2021-nzrse-conference/) | RSE Conference New Zealand |

--- a/_includes/events/2022.md
+++ b/_includes/events/2022.md
@@ -1,2 +1,6 @@
 | rSE22 | 2022-02-21 - 2022-02-25 | online | [Talks track](https://se-2022.gi.de/program/rse-workshops-und-bof); [Workshops](https://se-2022.gi.de/rse22workshops) | Run as part of GI [SE2022](https://se-2022.gi.de/) |
-| RSECon UK 2022 | 2022-09-06 - 2022-09-08 | Newcastle, UK | [society-rse.org/rse-conference-2022/](https://society-rse.org/rse-conference-2022/) |  |
+| RSECon2022 | 2022-09-06 - 2022-09-08 | Newcastle, UK | [society-rse.org/rse-conference-2022](https://society-rse.org/rse-conference-2022/) |  |
+| FOSDEM'22 | 2022-02-05 - 2022-02-06 | Brussels | [FOSDEM'22](https://archive.fosdem.org/2022/) | |
+| CRSC22 | 2022-05-31 - 2022-06-01 | Montreal | [CRSC22](https://www.canarie.ca/event/crsc-2022/) | Canadian Research Software Conference |
+| RSEAA22 | 2022-09-14 - 2022-09-16 | online | [RSEAA22](https://rseaa.org/RSEAA22.html) | RSE Asia Australia Unconference |
+| NZRSE 2022 | 2022-09-12 - 2022-09-13 | online | [NZRSE 2022](https://www.rseconference.nz/2022-nzrse-conference/) | RSE Conference New Zealand |

--- a/_includes/events/2023.md
+++ b/_includes/events/2023.md
@@ -1,2 +1,8 @@
 | deRSE 2023 | 2023-02-20 - 2023-02-21 | Heinz Nixdorf Forum Paderborn | [deRSE23](https://de-rse23.sciencesconf.org/) | Co-located with SE23 |
 | deRSE Unconference 2023 | 2023-09-26 - 2023-09-28 | Jena | [un-deRSE23](https://un-derse23.sciencesconf.org/index) | |
+| RSECon23 | 2023-09-05 - 2023-09-07 | Swansea, UK | [RSECon23](https://rsecon23.society-rse.org/) | |
+| US-RSE'23 | 2023-10-16 - 2023-10-18 | Chicago, USA | [US-RSE'23](https://us-rse.org/usrse23/) | |
+| FOSDEM'23 | 2023-02-04 - 2023-02-05 | Brussels | [FOSDEM'23](https://archive.fosdem.org/2023/) | |
+| Danish RSE Seminar 2023 | 2023-08-30 - 2023-08-31 | Funen, Denmark | [DIGHUMLAB 2023](https://web.archive.org/web/20240522000332/https://dighumlab.org/danish-rse-seminar-2023/) | |
+| RSEAA23 | 2023-09-13 - 2023-09-15 | online | [RSEAA23](https://rseaa.org/RSEAA23.html) | RSE Asia Australia Unconference |
+| NZRSE 2023 | 2023-09-18 - 2023-09-19 | online | [NZRSE 2023](https://www.rseconference.nz/2023-nzrse-virtual-conference/) | RSE Conference New Zealand |

--- a/_includes/events/2024.md
+++ b/_includes/events/2024.md
@@ -1,1 +1,7 @@
-| deRSE 2024 | 2024-03-05 - 2024-03-07 | Julius-Maximilian-Universität Würzburg | [https://go.uniwue.de/derse24](https://go.uniwue.de/derse24) | Tues 10am to Thurs 5pm |
+| deRSE24 | 2024-03-05 - 2024-03-07 | Julius-Maximilian-Universität Würzburg | [deRSE24](https://events.hifis.net/event/994/) | |
+| RSECon24 | 2024-09-03 - 2024-09-05 | Newcastle, UK | [RSECon24](https://rsecon24.society-rse.org/) | |
+| US-RSE'24 | 2024-10-15 - 2024-10-17 | Albuquerque, USA | [US-RSE'24](https://us-rse.org/usrse24/) | |
+| FOSDEM'24 | 2024-02-03 - 2024-02-04 | Brussels | [FOSDEM'24](https://archive.fosdem.org/2024/) | |
+| Nordic-RSE 2024 | 2024-05-30 - 2024-05-31 | Espoo, Finland | [Nordic-RSE 2024](https://nordic-rse.org/events/2024-in-person-conference/) | |
+| RSEAA24 | 2024-09-10 - 2024-09-13 | online | [RSEAA24](https://rseaa.org/) | RSE Asia Australia Unconference |
+| NZRSE 2024 | 2024-09-17 - 2024-09-18 | online | [NZRSE 2024](https://www.rseconference.nz/) | RSE Conference New Zealand |

--- a/_includes/events/2025.md
+++ b/_includes/events/2025.md
@@ -1,1 +1,4 @@
 | deRSE 2025 | 2025-02-25 - 2025-02-27 | Karlsruhe | [deRSE25](https://events.hifis.net/event/1741/) | co-located with [SE25](https://se2025.sdq.kastel.kit.edu/co-located-conferences/) |
+| RSECon25 | 2025-09 | Warwick, UK | [RSECon25](https://society-rse.org/) | |
+| US-RSE'25 | 2025-10 | Philadelphia, USA | [US-RSE'25](https://us-rse.org/usrse25/) | |
+| FOSDEM'25 | 2025-02-01 - 2025-02-02 | Brussels | [FOSDEM'25](https://fosdem.org/2025/) | |

--- a/en/events.md
+++ b/en/events.md
@@ -6,7 +6,8 @@ weight: 30
 
 # Events
 
-We think this list of events is relevant. That's why simply collected them in a table. We are not the organizers of of these events!
+We found these events to be relevant to the RSE community.
+The respective organizers can be found on the linked websites.
 
 If you think, we are missing an event, please [contact](join.html) us.
 


### PR DESCRIPTION
Description of changes:
- summarize conferences organized by RSE associations, RSE task forces, and FLOSS communities
- fix broken links, when necessary using the Wayback Machine