### PR TITLE
More RSE conferences

### DIFF
--- a/_includes/events/2015.md
+++ b/_includes/events/2015.md
@@ -1,0 +1,1 @@
+| RSS15 | 2015-10-01 - 2015-10-02 | Berlin | [RSS15 report](https://www.knowledge-exchange.info/event/software-sustainability) | Research Software Sustainability Workshop |

--- a/_includes/events/2016.md
+++ b/_includes/events/2016.md
@@ -1,0 +1,1 @@
+| RSE16 | 2016-09-15 - 2016-09-16 | Manchester | [RSE16](https://ukrse.github.io/conf2016.html) | |

--- a/_includes/events/2017.md
+++ b/_includes/events/2017.md
@@ -1,0 +1,11 @@
+| DANS/SSI Workshop on Software Sustainability | 7.-9.3.2017 | Den Haag | | |
+| Barcamp Open Science | 20.3.2017 | Berlin | [http://www.barcamp-open-science.eu/](http://www.barcamp-open-science.eu/) | free! |
+| Open Science Conference | 21.-22.3.2017 | Berlin | [http://www.open-science-conference.eu/](http://www.open-science-conference.eu/) | Early-Bird bis 14.2. |
+| Collaborations Workshop 2017 | 27.-29.3.2017 | Leeds | [https://www.software.ac.uk/cw17](https://www.software.ac.uk/cw17) | |
+| 2nd Conference on Non-Textual Information (S3) | 10.-11.5.2017 | Hannover | [https://events.tib.eu/nontextualinformation2017/](https://events.tib.eu/nontextualinformation2017/) | |
+| RDA-DE-Trainings-Workshop-2017 | 8.-9.6.2017 | Dresden | [http://www.forschungsdaten.org/index.php/RDA-DE-...-2017](http://www.forschungsdaten.org/index.php/RDA-DE-Trainings-Workshop-2017) | |
+| EuroSciPy 2017 | 28.8.-1.9. | Erlangen | [https://www.euroscipy.org/2017/](https://www.euroscipy.org/2017/) | |
+| RSE17 | 7.-8.9.2017 | Manchester | [https://rse.ac.uk/conf2017](https://web.archive.org/web/20220121001058/https://rse.ac.uk/conf2017/) | |
+| Open-Access-Tage 2017 | 11.-13.9.2017 | Dresden | [https://open-access.net/...](https://open-access.net/community/open-access-tage/open-access-tage-2017-dresden/) | |
+| WSSSPE5.2 | 24.10.2017 | Auckland | [wssspe.researchcomputing...wssspe5-2/](http://wssspe.researchcomputing.org.uk/category/wssspe5-2/) | [13th IEEE eScience](http://escience2017.org.nz) |
+| FORCE17 | 25.-27.10.2017 | Berlin | [https://www.force11.org/meetings/force2017](https://www.force11.org/meetings/force2017) | [open access week](http://www.openaccessweek.org) |

--- a/_includes/events/2017.md
+++ b/_includes/events/2017.md
@@ -1,11 +1,11 @@
-| DANS/SSI Workshop on Software Sustainability | 7.-9.3.2017 | Den Haag | | |
-| Barcamp Open Science | 20.3.2017 | Berlin | [http://www.barcamp-open-science.eu/](http://www.barcamp-open-science.eu/) | free! |
-| Open Science Conference | 21.-22.3.2017 | Berlin | [http://www.open-science-conference.eu/](http://www.open-science-conference.eu/) | Early-Bird bis 14.2. |
+| WoSSS17 | 7.-9.3.2017 | The Hague | [WoSSS17 report](https://doi.org/10.17026/dans-xfe-rn2w) | Workshop on Sustainable Software Sustainability |
+| Barcamp Open Science | 20.3.2017 | Berlin | [Barcamp Open Science 2017](https://web.archive.org/web/20170907213145/http://www.open-science-conference.eu/barcamp/) | free! |
+| Open Science Conference | 21.-22.3.2017 | Berlin | [OSC18](https://web.archive.org/web/20161016221713/http://www.open-science-conference.eu/) | |
 | Collaborations Workshop 2017 | 27.-29.3.2017 | Leeds | [https://www.software.ac.uk/cw17](https://www.software.ac.uk/cw17) | |
 | 2nd Conference on Non-Textual Information (S3) | 10.-11.5.2017 | Hannover | [https://events.tib.eu/nontextualinformation2017/](https://events.tib.eu/nontextualinformation2017/) | |
-| RDA-DE-Trainings-Workshop-2017 | 8.-9.6.2017 | Dresden | [http://www.forschungsdaten.org/index.php/RDA-DE-...-2017](http://www.forschungsdaten.org/index.php/RDA-DE-Trainings-Workshop-2017) | |
-| EuroSciPy 2017 | 28.8.-1.9. | Erlangen | [https://www.euroscipy.org/2017/](https://www.euroscipy.org/2017/) | |
+| RDA-DE-Trainings-Workshop-2017 | 8.-9.6.2017 | Dresden | [https://www.forschungsdaten.org/index.php/RDA-DE-...-2017](https://www.forschungsdaten.org/index.php/RDA-DE-Trainings-Workshop-2017) | |
+| EuroSciPy 2017 | 28.8.-1.9.2017 | Erlangen | [EuroSciPy 2017](https://web.archive.org/web/20170828124453/https://www.euroscipy.org/2017/) | |
 | RSE17 | 7.-8.9.2017 | Manchester | [https://rse.ac.uk/conf2017](https://web.archive.org/web/20220121001058/https://rse.ac.uk/conf2017/) | |
-| Open-Access-Tage 2017 | 11.-13.9.2017 | Dresden | [https://open-access.net/...](https://open-access.net/community/open-access-tage/open-access-tage-2017-dresden/) | |
-| WSSSPE5.2 | 24.10.2017 | Auckland | [wssspe.researchcomputing...wssspe5-2/](http://wssspe.researchcomputing.org.uk/category/wssspe5-2/) | [13th IEEE eScience](http://escience2017.org.nz) |
-| FORCE17 | 25.-27.10.2017 | Berlin | [https://www.force11.org/meetings/force2017](https://www.force11.org/meetings/force2017) | [open access week](http://www.openaccessweek.org) |
+| Open-Access-Tage 2017 | 11.-13.9.2017 | Dresden | [https://open-access-tage.de/...](https://open-access-tage.de/open-access-tage-2017-dresden) | |
+| WSSSPE5.2 | 24.10.2017 | Auckland | [WSSSPE5.2](https://wssspe.researchcomputing.org.uk/category/wssspe5-2/) | [13th IEEE eScience](http://escience2017.org.nz) |  |
+| FORCE17 | 25.-27.10.2017 | Berlin | [FORCE17](https://force11.org/force2017/) | [open access week 2017](https://web.archive.org/web/20170429085134/http://www.openaccessweek.org/profiles/blogs/2017-open-access-week-theme) | |

--- a/_includes/events/2018.md
+++ b/_includes/events/2018.md
@@ -7,4 +7,5 @@
 | Research Software Engineers in the Geosciences | 12.4.2018 | Vienna | [session information](http://meetingorganizer.copernicus.org/EGU2018/session/29539) + [registration](https://docs.google.com/forms/d/e/1FAIpQLSeolsrBOqBuUIn7_mM7rhKU_iKSl1ezl2s8bAgTy8hrkJxRpg/viewform) | part of [EGU General Assembly](https://egu2018.eu/) |
 | de-RSE @ FROSCON13 | 25 August 2018 | [Sankt Augustin](https://event.dlr.de/veranstaltungsort/hochschule-bonn-rhein-sieg/) | [Event website](https://event.dlr.de/event/de-rse-workshop-auf-der-froscon/) - [Programme](https://programm.froscon.de/2018/schedule/1.html) | free! |
 | RSE18 | 15 October 2018 | University of Birmingham | [www.rse.ac.uk/conf2018](https://web.archive.org/web/20210511160658/https://rse.ac.uk/conf2018/) |
+| CRSC18 | 29-30 May 2018 | Ottawa | [CRSC18](https://society-rse.org/events/candian-rse-conference/) | Canadian Research Software Conference |
 | Developer Forum 2018 | 3-4 September 2018 | Humboldt-Universität zu Berlin | [attending.io/events/developer-forum-2018](https://attending.io/events/developer-forum-2018) |

--- a/_includes/events/2019.md
+++ b/_includes/events/2019.md
@@ -7,4 +7,6 @@
 | deRSE19 | 4.-6.6.2019 | Potsdam | [www.de-rse.org/de/conf2019/](https://www.de-rse.org/de/conf2019/) |
 | FrOSCon | 10.-11.8.2019 | Sankt Augustin | [froscon.de](https://www.froscon.de/) |
 | Fourth RSE conference| 17-19 September 2019 | University of Birmingham | [rse.ac.uk/conf2019/](https://web.archive.org/web/20211009200055/https://rse.ac.uk/conf2019/) |
+| CRSC19 | 2019-05-28 - 2019-05-29 | Montreal | [CRSC19](https://web.archive.org/web/20190717162435/https://www.canarie.ca/software/canadian-research-software-conference/) | Canadian Research Software Conference |
 | NL-RSE19 | 2019-11-20 | Amsterdam | [nl-rse.org/events/nl-rse19](https://nl-rse.org/events/nl-rse19) | |
+| WoSSS19 | 2019-04-24 - 2019-04-26 | The Hague | [WoSSS19 report](https://doi.org/10.5281/zenodo.3922154) | Workshop on Sustainable Software Sustainability |

--- a/_includes/events/2020.md
+++ b/_includes/events/2020.md
@@ -1,5 +1,7 @@
 | SORSE | 09/2020-12/2020 | online | [https://sorse.github.io/](https://sorse.github.io/) | A Series of Online Research Software Events |
 | deRSE20 - _cancelled_ | ~~25.-27.8.2020~~ | ~~Jena~~ | [www.de-rse.org/deRSE20/](https://www.de-rse.org/deRSE20/) | |
+| CRSC20 - _cancelled_ | ~~2020-05-26 - 2020-05-27~~ | Montreal | [CRSC20](https://web.archive.org/web/20200815192456/https://www.canarie.ca/software/canadian-research-software-conference/) | Canadian Research Software Conference |
 | FOSDEM'20 | 2020-02-01 - 2020-02-02 | Brussels | [FOSDEM'20](https://archive.fosdem.org/2020/) | |
 | RSDD20 | 2020-12-03 | online | [www.be-rse.org/rsdd2020](https://web.archive.org/web/20200922063305/https://www.be-rse.org/rsdd2020) | Research Software Developers Day |
 | NZRSE 2020 | 2020-09-08 - 2020-09-10 | online | [NZRSE 2020](https://www.rseconference.nz/2020-nzrse-conference/) | RSE Conference New Zealand |
+| RSE-HPC-2020 | 2020-11-12 | online | [RSE-HPC-2020](https://us-rse.org/rse-hpc-2020/) | co-located with [SC20](https://sc20.supercomputing.org/) |

--- a/_includes/events/2021.md
+++ b/_includes/events/2021.md
@@ -4,3 +4,4 @@
 | FOSDEM'21 | 2021-02-06 - 2021-02-07 | online | [FOSDEM'21](https://archive.fosdem.org/2021/) | |
 | CRSC21 | 2021-07-06 - 2021-07-08 | online | [CRSC21](https://www.canarie.ca/event/crsc-2021/) | Canadian Research Software Conference |
 | NZRSE 2021 | 2021-09-15 - 2021-09-17 | online | [NZRSE 2021](https://www.rseconference.nz/2021-nzrse-conference/) | RSE Conference New Zealand |
+| RSE-HPC-2021 | 2021-11-15 | online | [RSE-HPC-2021](https://us-rse.org/rse-hpc-2021/) | co-located with [SC21](https://sc21.supercomputing.org/) |

--- a/_includes/events/2022.md
+++ b/_includes/events/2022.md
@@ -4,3 +4,4 @@
 | CRSC22 | 2022-05-31 - 2022-06-01 | Montreal | [CRSC22](https://www.canarie.ca/event/crsc-2022/) | Canadian Research Software Conference |
 | RSEAA22 | 2022-09-14 - 2022-09-16 | online | [RSEAA22](https://rseaa.org/RSEAA22.html) | RSE Asia Australia Unconference |
 | NZRSE 2022 | 2022-09-12 - 2022-09-13 | online | [NZRSE 2022](https://www.rseconference.nz/2022-nzrse-conference/) | RSE Conference New Zealand |
+| RSE-HPC-2022 | 2022-11-13 | Dallas | [RSE-HPC-2022](https://us-rse.org/rse-hpc-2022/) | co-located with [SC22](https://sc22.supercomputing.org/) |

--- a/_includes/events/2023.md
+++ b/_includes/events/2023.md
@@ -6,3 +6,4 @@
 | Danish RSE Seminar 2023 | 2023-08-30 - 2023-08-31 | Funen, Denmark | [DIGHUMLAB 2023](https://web.archive.org/web/20240522000332/https://dighumlab.org/danish-rse-seminar-2023/) | |
 | RSEAA23 | 2023-09-13 - 2023-09-15 | online | [RSEAA23](https://rseaa.org/RSEAA23.html) | RSE Asia Australia Unconference |
 | NZRSE 2023 | 2023-09-18 - 2023-09-19 | online | [NZRSE 2023](https://www.rseconference.nz/2023-nzrse-virtual-conference/) | RSE Conference New Zealand |
+| RSE-HPC-2023 | 2023-11-12 | Denver | [RSE-HPC-2023](https://us-rse.org/rse-hpc-2023/) | co-located with [SC23](https://sc23.supercomputing.org/) |

--- a/_includes/events/2024.md
+++ b/_includes/events/2024.md
@@ -5,3 +5,4 @@
 | Nordic-RSE 2024 | 2024-05-30 - 2024-05-31 | Espoo, Finland | [Nordic-RSE 2024](https://nordic-rse.org/events/2024-in-person-conference/) | |
 | RSEAA24 | 2024-09-10 - 2024-09-13 | online | [RSEAA24](https://rseaa.org/) | RSE Asia Australia Unconference |
 | NZRSE 2024 | 2024-09-17 - 2024-09-18 | online | [NZRSE 2024](https://www.rseconference.nz/) | RSE Conference New Zealand |
+| RSE-HPC-2024 | 2024-11-17 | Atlanta | [RSE-HPC-2024](https://us-rse.org/rse-hpc-2024/) | co-located with [SC24](https://sc24.supercomputing.org/) |

--- a/_includes/events/2024.md
+++ b/_includes/events/2024.md
@@ -5,4 +5,5 @@
 | Nordic-RSE 2024 | 2024-05-30 - 2024-05-31 | Espoo, Finland | [Nordic-RSE 2024](https://nordic-rse.org/events/2024-in-person-conference/) | |
 | RSEAA24 | 2024-09-10 - 2024-09-13 | online | [RSEAA24](https://rseaa.org/) | RSE Asia Australia Unconference |
 | NZRSE 2024 | 2024-09-17 - 2024-09-18 | online | [NZRSE 2024](https://www.rseconference.nz/) | RSE Conference New Zealand |
+| RSEHPC\@ISC24 | 2024-05-16 | Hamburg | [RSEHPC\@ISC24](https://www.rse-hpc.org/) | co-located with [ISC24](https://web.archive.org/web/20240516143637/https://isc-hpc.com/) |
 | RSE-HPC-2024 | 2024-11-17 | Atlanta | [RSE-HPC-2024](https://us-rse.org/rse-hpc-2024/) | co-located with [SC24](https://sc24.supercomputing.org/) |

--- a/_includes/events/2025.md
+++ b/_includes/events/2025.md
@@ -1,4 +1,5 @@
 | deRSE 2025 | 2025-02-25 - 2025-02-27 | Karlsruhe | [deRSE25](https://events.hifis.net/event/1741/) | co-located with [SE25](https://se2025.sdq.kastel.kit.edu/co-located-conferences/) |
 | RSECon25 | 2025-09-09 - 2025-09-11 | Warwick, UK | [RSECon25](https://rsecon25.society-rse.org/) | |
 | US-RSE'25 | 2025-10 | Philadelphia, USA | [US-RSE'25](https://us-rse.org/usrse25/) | |
+| Nordic-RSE 2025 | 2025-05-20 - 2025-05-21 | Gothenburg, Sweden | [Nordic-RSE 2025](https://nordic-rse.org/nrse2025/) | |
 | FOSDEM'25 | 2025-02-01 - 2025-02-02 | Brussels | [FOSDEM'25](https://fosdem.org/2025/) | |

--- a/_includes/events/2025.md
+++ b/_includes/events/2025.md
@@ -3,3 +3,5 @@
 | US-RSE'25 | 2025-10 | Philadelphia, USA | [US-RSE'25](https://us-rse.org/usrse25/) | |
 | Nordic-RSE 2025 | 2025-05-20 - 2025-05-21 | Gothenburg, Sweden | [Nordic-RSE 2025](https://nordic-rse.org/nrse2025/) | |
 | FOSDEM'25 | 2025-02-01 - 2025-02-02 | Brussels | [FOSDEM'25](https://fosdem.org/2025/) | |
+| ISS25 | 2025-04-07 - 2025-04-10 | Boulder, CO and online | [ISS25](https://sea.ucar.edu/iss/2025/) | Improving Scientific Software Conference |
+| S3C | 2025-05-05 - 2025-05-08 | Denver, CO | [S3C](https://s3c.sandia.gov/) | Sustainable Scientific Software Conference (S3C) |

--- a/_includes/events/2025.md
+++ b/_includes/events/2025.md
@@ -1,4 +1,4 @@
 | deRSE 2025 | 2025-02-25 - 2025-02-27 | Karlsruhe | [deRSE25](https://events.hifis.net/event/1741/) | co-located with [SE25](https://se2025.sdq.kastel.kit.edu/co-located-conferences/) |
-| RSECon25 | 2025-09 | Warwick, UK | [RSECon25](https://society-rse.org/) | |
+| RSECon25 | 2025-09-09 - 2025-09-11 | Warwick, UK | [RSECon25](https://rsecon25.society-rse.org/) | |
 | US-RSE'25 | 2025-10 | Philadelphia, USA | [US-RSE'25](https://us-rse.org/usrse25/) | |
 | FOSDEM'25 | 2025-02-01 - 2025-02-02 | Brussels | [FOSDEM'25](https://fosdem.org/2025/) | |

--- a/_includes/events/2025.md
+++ b/_includes/events/2025.md
@@ -1,7 +1,8 @@
 | deRSE 2025 | 2025-02-25 - 2025-02-27 | Karlsruhe | [deRSE25](https://events.hifis.net/event/1741/) | co-located with [SE25](https://se2025.sdq.kastel.kit.edu/co-located-conferences/) |
 | RSECon25 | 2025-09-09 - 2025-09-11 | Warwick, UK | [RSECon25](https://rsecon25.society-rse.org/) | |
-| US-RSE'25 | 2025-10 | Philadelphia, USA | [US-RSE'25](https://us-rse.org/usrse25/) | |
+| US-RSE'25 | 2025-10-06 - 2025-10-08 | Philadelphia, USA | [US-RSE'25](https://us-rse.org/usrse25/) | |
 | Nordic-RSE 2025 | 2025-05-20 - 2025-05-21 | Gothenburg, Sweden | [Nordic-RSE 2025](https://nordic-rse.org/nrse2025/) | |
 | FOSDEM'25 | 2025-02-01 - 2025-02-02 | Brussels | [FOSDEM'25](https://fosdem.org/2025/) | |
+| RSEHPC\@ISC25 | 2025-06-13 | Hamburg | [RSEHPC\@ISC25](https://www.helmholtz-hirse.de/events/2025_06_13-rsehpcatisc.html) | co-located with [ISC25](https://web.archive.org/web/20250127091253/https://isc-hpc.com/) |
 | ISS25 | 2025-04-07 - 2025-04-10 | Boulder, CO and online | [ISS25](https://sea.ucar.edu/iss/2025/) | Improving Scientific Software Conference |
 | S3C | 2025-05-05 - 2025-05-08 | Denver, CO | [S3C](https://s3c.sandia.gov/) | Sustainable Scientific Software Conference (S3C) |

--- a/de/events.md
+++ b/de/events.md
@@ -78,3 +78,17 @@ Die **deRSE**-Konferenzen sind von uns veranstaltete, internationale Konferenzen
 | --- | --- | --- | --- | --- |
 {% include events/2017.md %}
 {: .table .table-hover}
+
+## 2016
+
+| Veranstaltung | Datum | Ort | URL | Bemerkung |
+| --- | --- | --- | --- | --- |
+{% include events/2016.md %}
+{: .table .table-hover}
+
+## 2015
+
+| Veranstaltung | Datum | Ort | URL | Bemerkung |
+| --- | --- | --- | --- | --- |
+{% include events/2015.md %}
+{: .table .table-hover}

--- a/de/events.md
+++ b/de/events.md
@@ -51,7 +51,6 @@ Die **deRSE**-Konferenzen sind von uns veranstaltete, internationale Konferenzen
 {% include events/2021.md %}
 {: .table .table-hover}
 
-
 ## 2020
 
 | Veranstaltung | Datum | Ort | URL | Bemerkung |
@@ -77,16 +76,5 @@ Die **deRSE**-Konferenzen sind von uns veranstaltete, internationale Konferenzen
 
 | Veranstaltung | Datum | Ort | URL | Bemerkung |
 | --- | --- | --- | --- | --- |
-| DANS/SSI Workshop on Software Sustainability | 7.-9.3.2017 | Den Haag |
-| Barcamp Open Science | 20.3.2017 | Berlin | [www.barcamp-open-science.eu/](http://www.barcamp-open-science.eu/) | free! |
-| Open Science Conference | 21.-22.3.2017 | Berlin | [www.open-science-conference.eu/](http://www.open-science-conference.eu/) | Early-Bird bis 14.2. |
-| Collaborations Workshop 2017 | 27.-29.3.2017 | Leeds | [www.software.ac.uk/cw17](https://www.software.ac.uk/cw17) |
-| 2nd Conference on Non-Textual Information (S3) | 10.-11.5.2017 | Hannover | [https://events.tib.eu/nontextualinformation2017/](https://events.tib.eu/nontextualinformation2017/) |
-| RDA-DE-Trainings-Workshop-2017 | 8.-9.6.2017 | Dresden | [www.forschungsdaten.org/index.php/RDA-DE-...-2017](http://www.forschungsdaten.org/index.php/RDA-DE-Trainings-Workshop-2017) |
-| EuroSciPy 2017 | 28.8.-1.9. | Erlangen | [https://www.euroscipy.org/2017/](https://www.euroscipy.org/2017/) |
-| RSE17 | 7.-8.9.2017 | Manchester | [www.rse.ac.uk/conf2017](https://web.archive.org/web/20220121001058/https://rse.ac.uk/conf2017/) |
-| Open-Access-Tage 2017 | 11.-13.9.2017| Dresden | [open-access.net/...-tage-2017-dresden/](https://open-access.net/community/open-access-tage/open-access-tage-2017-dresden/) |
-| WSSSPE5.2 | 24.10.2017| Auckland| [wssspe.researchcomputing...wssspe5-2/](http://wssspe.researchcomputing.org.uk/category/wssspe5-2/) | [13th IEEE eScience](http://escience2017.org.nz) | 
-| FORCE17 | 25.-27.10.2017 | Berlin | [www.force11.org/meetings/force2017](https://www.force11.org/meetings/force2017) | [open access week](http://www.openaccessweek.org) |
+{% include events/2017.md %}
 {: .table .table-hover}
-

--- a/en/events.md
+++ b/en/events.md
@@ -75,15 +75,5 @@ We organize the international **deRSE** conferences, by and for Research Softwar
 
 | Event | Date | Place | URL | Remarks |
 | --- | --- | --- | --- | --- |
-| DANS/SSI Workshop on Software Sustainability | 7.-9.3.2017 | Den Haag |
-| Barcamp Open Science | 20.3.2017 | Berlin | [http://www.barcamp-open-science.eu/](http://www.barcamp-open-science.eu/) | free! |
-| Open Science Conference | 21.-22.3.2017 | Berlin | [http://www.open-science-conference.eu/](http://www.open-science-conference.eu/) | Early-Bird bis 14.2. |
-| Collaborations Workshop 2017 | 27.-29.3.2017 | Leeds | [https://www.software.ac.uk/cw17](https://www.software.ac.uk/cw17) |
-| 2nd Conference on Non-Textual Information (S3) | 10.-11.5.2017 | Hannover | [https://events.tib.eu/nontextualinformation2017/](https://events.tib.eu/nontextualinformation2017/) |
-| RDA-DE-Trainings-Workshop-2017 | 8.-9.6.2017 | Dresden | [http://www.forschungsdaten.org/index.php/RDA-DE-...-2017](http://www.forschungsdaten.org/index.php/RDA-DE-Trainings-Workshop-2017) |
-| EuroSciPy 2017 | 28.8.-1.9. | Erlangen | [https://www.euroscipy.org/2017/](https://www.euroscipy.org/2017/) |
-| RSE17 | 7.-8.9.2017 | Manchester | [https://rse.ac.uk/conf2017](https://web.archive.org/web/20220121001058/https://rse.ac.uk/conf2017/) |
-| Open-Access-Tage 2017 | 11.-13.9.2017| Dresden | [https://open-access.net/...](https://open-access.net/community/open-access-tage/open-access-tage-2017-dresden/) |
-| WSSSPE5.2 | 24.10.2017| Auckland| [wssspe.researchcomputing...wssspe5-2/](http://wssspe.researchcomputing.org.uk/category/wssspe5-2/) | [13th IEEE eScience](http://escience2017.org.nz) | 
-| FORCE17 | 25.-27.10.2017 | Berlin | [https://www.force11.org/meetings/force2017](https://www.force11.org/meetings/force2017) | [open access week](http://www.openaccessweek.org) |
+{% include events/2017.md %}
 {: .table .table-hover}

--- a/en/events.md
+++ b/en/events.md
@@ -77,3 +77,17 @@ We organize the international **deRSE** conferences, by and for Research Softwar
 | --- | --- | --- | --- | --- |
 {% include events/2017.md %}
 {: .table .table-hover}
+
+## 2016
+
+| Event | Date | Place | URL | Remarks |
+| --- | --- | --- | --- | --- |
+{% include events/2016.md %}
+{: .table .table-hover}
+
+## 2015
+
+| Event | Date | Place | URL | Remarks |
+| --- | --- | --- | --- | --- |
+{% include events/2015.md %}
+{: .table .table-hover}


### PR DESCRIPTION
Description of changes:

* consolidate RSE conferences from 2017 duplicated on the English and German pages
* add RSE conferences from North America
* add RSE conferences from 2015 and 2016