### PR TITLE
Add deRSE 2026 to the events

### DIFF
--- a/_includes/events/2026.md
+++ b/_includes/events/2026.md
@@ -1,0 +1,1 @@
+| deRSE26 | 2026-03-03 - 2026-03-05 | Stuttgart | pending | Satellite events possible on March 2 |

--- a/de/events.md
+++ b/de/events.md
@@ -16,6 +16,13 @@ Falls eine Veranstaltung fehlt, [kontaktiere](join.html) uns bitte.
 
 Die **deRSE**-Konferenzen sind internationale Konferenzen in der deutschen RSE-Community von und für Research Software Engineers.
 
+## 2026
+
+| Veranstaltung | Datum | Ort | URL | Bemerkung |
+| --- | --- | --- | --- | --- |
+{% include events/2026.md %}
+{: .table .table-hover}
+
 ## 2025
 
 | Veranstaltung | Datum | Ort | URL | Bemerkung |

--- a/en/events.md
+++ b/en/events.md
@@ -15,6 +15,13 @@ If you think, we are missing an event, please [contact](join.html) us.
 
 The **deRSE** conferences are international conferences in the German RSE community by and for Research Software Engineers.
 
+## 2026
+
+| Event | Date | Place | URL | Remarks |
+| --- | --- | --- | --- | --- |
+{% include events/2026.md %}
+{: .table .table-hover}
+
 ## 2025
 
 | Event | Date | Place | URL | Remarks |


### PR DESCRIPTION
Adds the deRSE26 to https://de-rse.org/en/events.html (en/de).

Website pending.

Related to https://github.com/DE-RSE/projekte/issues/21

@berndflemisch I added the "satellite events possible on March 2" (meaning a potential "Stuttgart Research Software Day"), so that people keep this in mind for their travel planning. We should announce that in the same table, if fixed.