### PR TITLE
Remove GWDG RocketChat references

### DIFF
--- a/de/join.md
+++ b/de/join.md
@@ -47,7 +47,7 @@ Eine Liste dieser Kanäle und Informationen für den Einstig in die Nutzung von 
 ## Stellenangebote
 
 Stellenangebote können über folgende Kanäle beworben werden:
-- GWDG RocketChat Kanal: <https://chat.gwdg.de/channel/derse_jobs>
+- Matrix-Kanal: <https://matrix.to/#/#de-rse.org-jobs:matrix.org>
 - Mailing Liste (bitte den Betreff mit "[JOBS]" beginnen, z.B. "[JOBS] unbefristete Stelle als RSE Gruppenleitung")
 
 ## Monatlicher Call

--- a/en/join.md
+++ b/en/join.md
@@ -45,14 +45,10 @@ create a financial problem.
 Please don't use the mailing list for long discussions, use the chat channel(s) instead!
 You can find a list of these channels and some information on how to start using Matrix chat on a [separate page](matrix.html).
 
-#### (alter Chat: Rocketchat)
-
-Before Matrix we used RocketChat from GWDG: <https://chat.gwdg.de/channel/derse>.
-
 ## Job offers
 
-Job offers can be announced through the followin channels:
-- GWDG RocketChat Channel: <https://chat.gwdg.de/channel/derse_jobs>
+Job offers can be announced through the following channels:
+- Matrix channel: <https://matrix.to/#/#de-rse.org-jobs:matrix.org>
 - Mailing list (please start you subject line with "[JOBS]", for example "[JOBS] permanent position as RSE group leader")
 
 ## Monthly Community Call


### PR DESCRIPTION
The GWDG RocketChat no longer exists. Therefore this commit removes the corresponding references and replaces them with references for Matrix where applicable.