### PR TITLE
Events 2026: Add Stuttgart Research Software Day, update deRSE26

### DIFF
--- a/_includes/events/2026.md
+++ b/_includes/events/2026.md
@@ -1,2 +1,3 @@
-| deRSE26 | 2026-03-03 - 2026-03-05 | Stuttgart | [deRSE26](https://events.hifis.net/e/derse26) | call for contributions opens Sep 22, 2025; satellite events possible on March 2 |
+| Stuttgart Research Software Day | 2026-03-02 - 2026-03-02 |  Stuttgart | [invitation](https://www.iws.uni-stuttgart.de/en/lh2/conferences-seminars-workshops/research-software-day/) | |
+| deRSE26 | 2026-03-03 - 2026-03-05 | Stuttgart | [deRSE26](https://events.hifis.net/e/derse26) | |
 | RSECon26 | 2025-09 | TBA | [call for RSECon26](https://society-rse.org/call-for-programme-chairs-rsecon26/) | |


### PR DESCRIPTION
- Adds https://www.iws.uni-stuttgart.de/en/lh2/conferences-seminars-workshops/research-software-day/ to the events
- Removes the deRSE26 call for contributions (closed)