### PR TITLE
Add cross-platform conda env manifest and describe use

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,7 @@ gem 'wdm', '~> 0.1.1' if Gem.win_platform?
 
 gem 'rake'
 
-gem 'jekyll'
-gem 'liquid', '>= 5.5.0'
-gem "kramdown", ">= 2.3.0"
+gem 'jekyll', ">= 4.4.1"
 gem 'jekyll-feed', group: :jekyll_plugins
 gem 'jekyll-redirect-from', group: :jekyll_plugins
 gem "kramdown-parser-gfm"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ This repository contains the source files for the de-RSE website. Its official h
 
 The site is made to be built with [Jekyll](https://jekyllrb.com/) >= 3.4.1.
 
-You can use [RVM](https://rvm.io/) to install and use a suitable Ruby version, e.g., `rvm use 2.7`.
+You can use, e.g.,
+
+- [RVM](https://rvm.io/) to install and use a suitable Ruby version, e.g., `rvm use 2.7`.
+- [`conda`/`mamba`] to install dependencies into a reproducible environment via `mamba env create -f conda-env-de-rse-website.yml && mamba activate de-rse-website`.
 
 To build, run `bundle install` once (or skip that if you have dependencies already installed and bundler does not work for you) and then  `bundle exec jekyll build`.
 To preview locally, run `bundle exec jekyll serve --incremental` and browse to <http://localhost:4000>.

--- a/conda-env-de-rse-website.yml
+++ b/conda-env-de-rse-website.yml
@@ -1,0 +1,8 @@
+name: de-rse-website
+channels:
+  - conda-forge
+dependencies:
+  - c-compiler
+  - compilers
+  - cxx-compiler
+  - ruby

--- a/conda-env-de-rse-website.yml
+++ b/conda-env-de-rse-website.yml
@@ -5,4 +5,4 @@ dependencies:
   - c-compiler
   - compilers
   - cxx-compiler
-  - ruby
+  - ruby=4.0.*


### PR DESCRIPTION
This PR adds another option for installing the required dependencies for local builds.

- The `.yml` file declares the required dependencies in an OS-independent way.
- `README.md` has been updated to document its use.