### PR TITLE
Prepare fix #270

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For all flags use the `--help` flag.
 
 ## Contributions
 
-To contribute, please fork, change, test locally (see above) and create a pull request against `master`.
+To contribute, please fork, change, test locally (see above) and create a pull request against `main`.
 
 You can use [rake](http://rake.rubyforge.org/) to comfortably create content.
 
@@ -84,13 +84,13 @@ For help on syntax have a look at:
 
 ## Map
 
-The map is fed by [mapdata.js](https://github.com/DE-RSE/de-rse.github.io/blob/master/_includes/mapdata.js). Adding someone to the map is as simple as adding a new section in this geoJSON file. Coordinates are available from [http://geojson.io/](http://geojson.io/) . Right now pictures should be 75px high. Inspiration for a nice testimonial can be found at Stephan Druskat's entry.
+The map is fed by [mapdata.js](https://github.com/DE-RSE/de-rse.github.io/blob/main/_includes/mapdata.js). Adding someone to the map is as simple as adding a new section in this geoJSON file. Coordinates are available from [http://geojson.io/](http://geojson.io/) . Right now pictures should be 75px high. Inspiration for a nice testimonial can be found at Stephan Druskat's entry.
 
 The map appeared on Dec 6th 2017 on the website. It's based on [leaflet](http://leafletjs.com) v1.2 and [Leaflet.markercluster](https://github.com/Leaflet/Leaflet.markercluster)
 
 ## Events
 
-Events are included per year from <https://github.com/DE-RSE/de-rse.github.io/tree/master/_includes/events>. No language specific remarks in favor of maintainability.
+Events are included per year from <https://github.com/DE-RSE/de-rse.github.io/tree/main/_includes/events>. No language specific remarks in favor of maintainability.
 
 ## Converting slack signup domain list
 

--- a/_drafts/i-am-a-test-draft.md
+++ b/_drafts/i-am-a-test-draft.md
@@ -14,6 +14,6 @@ It's simple, really.
 Once you're finished, save me under a new name (e.g., "my-real-draft.md") in the `_drafts` directory (where I also live).
 Then, run `rake publish` and pick me from all the drafts listed, to publish me.
 
-Once you're done, simply push your clone of the `master` branch back to your repository, and create a *pull request* against `master` on [my repository](https://github.com/DE-RSE/www).
+Once you're done, simply push your clone of the `main` branch back to your repository, and create a *pull request* against `main` on [my repository](https://github.com/DE-RSE/www).
 
 You're done :).

--- a/_posts/2017-03-22-welcome-to-the-de-rse-blog.md
+++ b/_posts/2017-03-22-welcome-to-the-de-rse-blog.md
@@ -7,7 +7,7 @@ menulang: en
 
 This weblog will contain posts on subjects that are relevant to the Research Software Engineers community.
 
-**You, too**, can contribute (in English or German). Simply clone [this website's GitHub repository](https://github.com/DE-RSE/de-rse.github.io/), check out the [README](https://github.com/DE-RSE/de-rse.github.io/blob/master/README.md) (we use [Jekyll](https://jekyllrb.com/), and it's easy to create and publish drafts with `rake`), create a blog post, and submit it to us via a GitHub pull request against `master`!
+**You, too**, can contribute (in English or German). Simply clone [this website's GitHub repository](https://github.com/DE-RSE/de-rse.github.io/), check out the [README](https://github.com/DE-RSE/de-rse.github.io/blob/main/README.md) (we use [Jekyll](https://jekyllrb.com/), and it's easy to create and publish drafts with `rake`), create a blog post, and submit it to us via a GitHub pull request against `main`!
 
 Happy reading, happy contributing!
 

--- a/_posts/2017-03-22-willkommen-beim-de-rse-blog.md
+++ b/_posts/2017-03-22-willkommen-beim-de-rse-blog.md
@@ -7,7 +7,7 @@ menulang: de
 
 Dieses Weblog wird Artikel beinhalten, die für die Research Software Engineers Community relevant sind.
 
-**Jede\*r** kann beitragen (auf Deutsch oder Englisch). Einfach das [GitHub repository dieser Website](https://github.com/DE-RSE/de-rse.github.io/) klonen, sich die [README](https://github.com/DE-RSE/de-rse.github.io/blob/master/README.md) anschauen (wir benutzen [Jekyll](https://jekyllrb.com/) und es ist einfach, mit `rake` Artikelentwürfe zu generieren und zu veröffentlichen), einen Artikel schreiben und ihn per GitHub Pull Request gegen `master` einreichen!
+**Jede\*r** kann beitragen (auf Deutsch oder Englisch). Einfach das [GitHub repository dieser Website](https://github.com/DE-RSE/de-rse.github.io/) klonen, sich die [README](https://github.com/DE-RSE/de-rse.github.io/blob/main/README.md) anschauen (wir benutzen [Jekyll](https://jekyllrb.com/) und es ist einfach, mit `rake` Artikelentwürfe zu generieren und zu veröffentlichen), einen Artikel schreiben und ihn per GitHub Pull Request gegen `main` einreichen!
 
 Viel Spaß beim Lesen und Beitragen!
 

--- a/_posts/2026-06-29-ROR-de.md
+++ b/_posts/2026-06-29-ROR-de.md
@@ -1,0 +1,17 @@
+---
+title: "de-RSE e.V. in der Research Organization Registry (ROR): 007qpef44"
+layout: post
+author: "Frank Löffler"
+menulang: de
+---
+![](https://raw.githubusercontent.com/ror-community/ror-logos/main/ror-icon-rgb.svg){: width="250px"}de-RSE e. V.: [https://ror.org/007qpef44](https://ror.org/007qpef44)
+
+Die „Research Organization Registry“, oder kurz oft einfach nur ROR, ist eine Datenbank für dauerhafte Kennungen von Einrichtungen im wissenschaftlichen Umfeld.
+Diese „persistent identifier“ sollen ähnlich wie [ORCID](https://info.orcid.org/what-is-orcid/)s, die dies für Personen tun, eindeutige Referenzen zu eben diesen Einrichtungen bereitstellen, unabhängig von ggf. gleichen oder ähnlichen Namen verschiedener Organisationen oder auch Namens- und Sprachvarianten ein und der gleichen Einrichtung.
+
+Zahlreiche Verlage erlauben schon die Verwendung von RORs bei der Angabe von Personenzugehörigkeiten.
+Auch in eurem Profil auf [ORCID](https://info.orcid.org/what-is-orcid/) lassen sich entsprechende Einträge [hinzufügen](https://info.orcid.org/de/add-research-institution-identifiers-with-ror/).
+Die Gesellschaft für Forschungssoftware hat nun ebenfalls eine solche ROR: [007qpef44](https://ror.org/007qpef44).
+In Zukunft gibt es damit immer eine Möglichkeit, den Verein zweifelsfrei zu referenzieren.
+Als Mitglied (oder Mitarbeitender) des Vereins könnt ihr sie zum Beispiel benutzen, um eure Zugehörigkeit zur Gesellschaft in Veröffentlichungen sichtbar zu machen, wenn die Arbeit im Zusammenhang mit dem Verein entstanden ist.
+

--- a/_posts/2026-06-29-ROR-en.md
+++ b/_posts/2026-06-29-ROR-en.md
@@ -1,8 +1,8 @@
 ---
-title: "de-RSE e.V. in der Research Organization Registry (ROR): 007qpef44"
+title: "de-RSE e.V. in the Research Organization Registry (ROR): 007qpef44"
 layout: post
 author: "Frank Löffler"
-menulang: de
+menulang: en
 ---
 ![](https://raw.githubusercontent.com/ror-community/ror-logos/main/ror-icon-rgb.svg){: width="250px"}de-RSE e. V.: [https://ror.org/007qpef44](https://ror.org/007qpef44)
 

--- a/_posts/2026-06-29-ROR-en.md
+++ b/_posts/2026-06-29-ROR-en.md
@@ -1,0 +1,16 @@
+---
+title: "de-RSE e.V. in der Research Organization Registry (ROR): 007qpef44"
+layout: post
+author: "Frank Löffler"
+menulang: de
+---
+![](https://raw.githubusercontent.com/ror-community/ror-logos/main/ror-icon-rgb.svg){: width="250px"}de-RSE e. V.: [https://ror.org/007qpef44](https://ror.org/007qpef44)
+
+The “Research Organisation Registry”, often referred to simply as ROR for short, is a database of persistent identifiers for organisations in the academic sector.
+Similar to [ORCID](https://info.orcid.org/what-is-orcid/)s, which serve this purpose for individuals, these “persistent identifiers” are intended to provide unique references to these organisations, regardless of potential identical or similar names of different organisations, or language or other variations of the name for the same organisation.
+
+Numerous publishers already allow the use of RORs when specifying an individual’s affiliations.
+You can also [add](https://info.orcid.org/de/add-research-institution-identifiers-with-ror/) corresponding entries to your profile on [ORCID](https://info.orcid.org/what-is-orcid/).
+The Society for Research Software in Germany now also has such a ROR: [007qpef44](https://ror.org/007qpef44).
+This means that from now on, you have a persistent way to reference the Society.
+As a member (or staff) of the Society, you can use it, for example, to indicate your affiliation with the Society in publications that somehow connect to it.

--- a/de/join.md
+++ b/de/join.md
@@ -63,7 +63,7 @@ Termine für die monatlichen Calls findet Ihr [hier](https://pad.okfn.de/p/opens
 
 Der Blog auf der Webseite wird von der Community gemeinschaftlich gestaltet.
 Deine Ideen, Themen und Beiträge auf Deutsch, English, oder beidem sind sehr willkommen!
-In der Datei [README.md](https://github.com/DE-RSE/de-rse.github.io/blob/master/README.md)
+In der Datei [README.md](https://github.com/DE-RSE/de-rse.github.io/blob/main/README.md)
 findest du eine Anleitung wie Du eine Vorschau der Seite auf deinem eigenen Rechner bekommen
 kannst.
 

--- a/de/map.md
+++ b/de/map.md
@@ -10,7 +10,7 @@ Andernorts in Europa und in der Welt werden Personen, die wissenschaftliche Soft
 
 de-RSE adressiert gleichermaßen Software entwickelnde Wissenschaftlerinnen und Wissenschaftler, in der Forschung tätige Informatikerinnen und Informatiker und andere aus den Computerwissenschaften stammende Personen, skriptende Administratorinnen und Administratoren, (Post-)Doktorandinnen und (Post-)Doktoranden, in der Forschung tätige Studentinnen und Studenten, Softwareprojektmanagerinnen und -projektmanager sowie all jene, die einen Beitrag zur Softwareentwicklung in Wissenschaft und Forschung leisten.
 
-Zeig, dass Du dazu gehörst: <https://github.com/DE-RSE/de-rse.github.io/blob/master/_includes/mapdata.js>
+Zeig, dass Du dazu gehörst: <https://github.com/DE-RSE/de-rse.github.io/blob/main/_includes/mapdata.js>
 
 Wie-andere-RSE-definieren: <https://www.de-rse.org/de/map.html#wie-andere-rse-definieren>
 

--- a/en/join.md
+++ b/en/join.md
@@ -63,7 +63,7 @@ Dates and times for the monthly community calls are [listed here](https://pad.ok
 
 The website hosts a blog with contributions from the community members.
 Your ideas, topics and posts in German, English, or both are very welcome!
-The [README.md](https://github.com/DE-RSE/de-rse.github.io/blob/master/README.md) includes instructions for getting a local preview of the site.
+The [README.md](https://github.com/DE-RSE/de-rse.github.io/blob/main/README.md) includes instructions for getting a local preview of the site.
 
 ## Local RSE groups
 

--- a/en/map.md
+++ b/en/map.md
@@ -10,7 +10,7 @@ Elsewhere in Europe and the world, people who develop scientific software or res
 
 de-RSE addresses both, software-developing researchers, PhD students and postdocs as well as computer scientists and other computer science professionals, scripting administrators and software project managers active in research - and all those who professionally contribute to software development in science and research.
 
-Is this you? Then add yourself and show who we are: <https://github.com/DE-RSE/de-rse.github.io/blob/master/_includes/mapdata.js>
+Is this you? Then add yourself and show who we are: <https://github.com/DE-RSE/de-rse.github.io/blob/main/_includes/mapdata.js>
 
 What others say what an RSE is: <https://www.de-rse.org/en/map.html#what-others-say-what-an-rse-is>
 


### PR DESCRIPTION
This PR prepares to fix #270 for this repository.

**Note: Do not merge, instead, follow "Fixing..." below.**

### Done:

- Replace relevant instances of `master` with `main` in content:
    - `for F in $(ack -l master); do sed -i 's~`master`~`main`~g' $F; done`
    - `for F in $(ack -l master); do sed -i 's~de-rse.github.io/blob/master~de-rse.github.io/blob/main~g' $F; done`
    - Manual check and replacement of `de-rse.github.io/tree/master`
- Manual check of replacement of false positives (`ack master` in repo root)

### Fixing #270 (for this repo)

I think this is basically now:

- Set `main` branch as default
- See if page builds and deploys (assuming Action uses default branch)
- Remove/rename `master` branch