### PR TITLE
fix navbar for 768px < width < 994px

### DIFF
--- a/css/de-rse.css
+++ b/css/de-rse.css
@@ -158,3 +158,59 @@ blockquote {
     }
   }
 }
+
+/* Collapse navbar at <994px instead of <768px */
+@media (max-width: 993px) {
+  .navbar .container-navbar {
+    width: auto;
+    margin-right: 0;
+  }
+  .navbar .navbar-header {
+    float: none !important;
+    width: auto;
+    overflow: hidden;
+  }
+  .navbar .navbar-toggle {
+    display: block;
+    float: right;
+  }
+  .navbar .navbar-collapse {
+    border-top: 1px solid transparent;
+    -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, .1);
+            box-shadow: inset 0 1px 0 rgba(255, 255, 255, .1);
+  }
+  .navbar .navbar-collapse.collapse {
+    display: none !important;
+    height: 0 !important;
+    overflow: hidden !important;
+  }
+  .navbar .navbar-collapse.collapse.in {
+    display: block !important;
+    height: auto !important;
+    overflow-y: auto !important;
+  }
+  .navbar.navbar-fixed-top .navbar-collapse,
+  .navbar.navbar-static-top .navbar-collapse,
+  .navbar.navbar-fixed-bottom .navbar-collapse {
+    padding-right: 15px;
+    padding-left: 15px;
+  }
+  .navbar .container > .navbar-header,
+  .navbar .container-fluid > .navbar-header,
+  .navbar .container > .navbar-collapse,
+  .navbar .container-fluid > .navbar-collapse {
+    margin-right: -15px !important;
+    margin-left: -15px !important;
+  }
+  .navbar .navbar-nav {
+    float: none !important;
+    margin: 7.5px -15px;
+  }
+  .navbar .navbar-nav > li {
+    float: none;
+  }
+  .navbar .navbar-nav > li > a {
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+}


### PR DESCRIPTION
The navbar would linebreak the language selector into a second line between 768 and 994 pixels, thus covering part of the main text. This PR extends the mobile-type burger menu navigation to widths below 994 pixels. Beautiful is different, but now all info is visible at these browser window sizes.